### PR TITLE
docs: Fix a few typos

### DIFF
--- a/Zeroconf.py
+++ b/Zeroconf.py
@@ -328,7 +328,7 @@ class DNSRecord(DNSEntry):
         raise AbstractMethodException
 
     def toString(self, other):
-        """String representation with addtional information"""
+        """String representation with additional information"""
         arg = "%s/%s,%s" % (self.ttl, self.getRemainingTTL(currentTimeMillis()), other)
         return DNSEntry.toString(self, "record", arg)
 
@@ -896,7 +896,7 @@ class Listener(object):
     to cache information as it arrives.
 
     It requires registration with an Engine object in order to have
-    the read() method called when a socket is availble for reading."""
+    the read() method called when a socket is available for reading."""
     
     def __init__(self, zeroconf):
         self.zeroconf = zeroconf
@@ -1250,7 +1250,7 @@ class Zeroconf(object):
             # SO_REUSEADDR should be equivalent to SO_REUSEPORT for
             # multicast UDP sockets (p 731, "TCP/IP Illustrated,
             # Volume 2"), but some BSD-derived systems require
-            # SO_REUSEPORT to be specified explicity.  Also, not all
+            # SO_REUSEPORT to be specified explicitly.  Also, not all
             # versions of Python have SO_REUSEPORT available.  So
             # if you're on a BSD-based system, and haven't upgraded
             # to Python 2.3 yet, you may find this library doesn't


### PR DESCRIPTION
There are small typos in:
- Zeroconf.py

Fixes:
- Should read `explicitly` rather than `explicity`.
- Should read `available` rather than `availble`.
- Should read `additional` rather than `addtional`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md